### PR TITLE
Use null-propagating and null-coalescing operator where appropriate #28

### DIFF
--- a/CoreTestClient/BaseSceneControl.cs
+++ b/CoreTestClient/BaseSceneControl.cs
@@ -129,8 +129,7 @@ namespace CoreTestClient
             private set
             {
                 hoveredPosition = value;
-                if (OnHoveredPositionChanged != null)
-                    OnHoveredPositionChanged(value);
+                OnHoveredPositionChanged?.Invoke(value);
             }
         }
 
@@ -141,11 +140,9 @@ namespace CoreTestClient
             get { return hoveredCell; }
             private set
             {
-                if (hoveredCell != value && OnHoveredCellChanged != null)
-                {
-                    hoveredCell = value;
-                    OnHoveredCellChanged(value);
-                }
+                hoveredCell = value;
+                if (hoveredCell != value)
+                    OnHoveredCellChanged?.Invoke(value);
             }
         }
 
@@ -307,10 +304,7 @@ namespace CoreTestClient
                                 }
 
                                 TileRenderer tileRenderer = OnRenderTile(x, y, out orientation);
-                                if (tileRenderer != null)
-                                    tileRenderer.Draw(g, x * TILEWIDTH, y * TILEWIDTH, orientation);
-
-                                
+                                tileRenderer?.Draw(g, x * TILEWIDTH, y * TILEWIDTH, orientation);
                             }
                         }
 
@@ -348,9 +342,9 @@ namespace CoreTestClient
         protected void SetMapSize(Index2 size)
         {
             // Dispose old Buffer (Size does not fit)
-            if (buffer != null && size != mapSize)
+            if (size != mapSize)
             {
-                buffer.Dispose();
+                buffer?.Dispose();
                 buffer = null;
             }
 
@@ -371,7 +365,6 @@ namespace CoreTestClient
             // Recreate a new Buffer
             if (buffer == null)
             {
-                mapSize = size;
                 buffer = new Bitmap(mapSize.X * TILEWIDTH, mapSize.Y * TILEWIDTH);
             }
 

--- a/CoreTestClient/EditorSceneControl.cs
+++ b/CoreTestClient/EditorSceneControl.cs
@@ -69,8 +69,7 @@ namespace CoreTestClient
             if (this.map != map)
             {
                 this.map = map;
-                if (map != null) SetMapSize(map.GetCellCount());
-                else SetMapSize(Index2.Zero);
+                SetMapSize(map?.GetCellCount() ?? Index2.Zero);
             }
         }
 

--- a/CoreTestClient/MapControl.cs
+++ b/CoreTestClient/MapControl.cs
@@ -40,8 +40,7 @@ namespace CoreTestClient
             if (this.map != map)
             {
                 this.map = map;
-                if (map != null) SetMapSize(map.GetCellCount());
-                else SetMapSize(Index2.Zero);
+                SetMapSize(map?.GetCellCount() ?? Index2.Zero);
             }
         }
 

--- a/CoreTestClient/Screens/SingleGameControl.cs
+++ b/CoreTestClient/Screens/SingleGameControl.cs
@@ -88,8 +88,8 @@ namespace CoreTestClient.Screens
 
         private void UpdateView()
         {
-            int min = level != null ? level.LevelDescription.MinPlayerCount : 0;
-            int max = level != null ? level.LevelDescription.MaxPlayerCount : 0;
+            int min = level?.LevelDescription.MinPlayerCount ?? 0;
+            int max = level?.LevelDescription.MaxPlayerCount ?? 0;
 
             for (int i = 1; i <= 8; i++)
             {

--- a/CoreTestClient/Tools/EditorTool.cs
+++ b/CoreTestClient/Tools/EditorTool.cs
@@ -43,8 +43,7 @@ namespace CoreTestClient.Tools
 
         protected void Select()
         {
-            if (OnSelect != null)
-                OnSelect(this, new EventArgs());
+            OnSelect?.Invoke(this, new EventArgs());
         }
 
         public event EventHandler OnSelect;

--- a/CoreTestClient/Tools/MapTileTool.cs
+++ b/CoreTestClient/Tools/MapTileTool.cs
@@ -56,9 +56,7 @@ namespace CoreTestClient.Tools
                 return;
 
             MapTile tile = map[cell.Value.X, cell.Value.Y];
-            MapMaterial material = null;
-            if (tile != null)
-                material = tile.Material;
+            MapMaterial material = tile?.Material;
 
             if (selected == null)
                 throw new NotSupportedException("No Map Tile selected");

--- a/CoreTestClient/Tools/MaterialTool.cs
+++ b/CoreTestClient/Tools/MaterialTool.cs
@@ -52,7 +52,7 @@ namespace CoreTestClient.Tools
             if (!cell.HasValue)
                 return false;
 
-            return (map != null && map[cell.Value.X, cell.Value.Y] != null);
+            return (map?[cell.Value.X, cell.Value.Y] != null);
         }
 
         protected override void OnApply(Map map, Index2? cell, Vector2? position)

--- a/CoreTestClient/Tools/SelectionTool.cs
+++ b/CoreTestClient/Tools/SelectionTool.cs
@@ -17,8 +17,7 @@ namespace CoreTestClient.Tools
             set
             {
                 selectedCell = value;
-                if (OnSelectedCellChanged != null)
-                    OnSelectedCellChanged(value);
+                OnSelectedCellChanged?.Invoke(value);
             }
         }
 

--- a/src/AntMe.Basics/EngineProperties/PhysicsGroup.cs
+++ b/src/AntMe.Basics/EngineProperties/PhysicsGroup.cs
@@ -317,8 +317,7 @@ namespace AntMe.Basics.EngineProperties
             #endregion
 
             // Änderungen weiter geben
-            if (load != null)
-                load.Recalc();
+            load?.Recalc();
         }
 
         /// <summary>
@@ -415,10 +414,8 @@ namespace AntMe.Basics.EngineProperties
             }
 
             // Kollision melden
-            if (collidable != null)
-                collidable.CollideItem(cluster.Item);
-            if (cluster.collidable != null)
-                cluster.collidable.CollideItem(Item);
+            collidable?.CollideItem(cluster.Item);
+            cluster.collidable?.CollideItem(Item);
         }
 
         /// <summary>
@@ -689,9 +686,8 @@ namespace AntMe.Basics.EngineProperties
         /// <param name="direction"></param>
         private void TriggerBorderEvent(Compass direction)
         {
-            if (moving != null && map.BlockBorder)
-
-                moving.HitBorder(direction);
+            if (map.BlockBorder)
+                moving?.HitBorder(direction);
         }
 
         #endregion
@@ -804,8 +800,7 @@ namespace AntMe.Basics.EngineProperties
         /// <param name="direction"></param>
         private void TriggerCellEvent(Compass direction)
         {
-            if (moving != null)
-                moving.HitWall(direction);
+            moving?.HitWall(direction);
         }
 
         #endregion
@@ -833,7 +828,7 @@ namespace AntMe.Basics.EngineProperties
         /// </summary>
         public float Radius
         {
-            get { return (collidable != null ? collidable.CollisionRadius : 0); }
+            get { return collidable?.CollisionRadius ?? 0; }
         }
 
         /// <summary>
@@ -849,7 +844,7 @@ namespace AntMe.Basics.EngineProperties
         /// </summary>
         public bool IsFixed
         {
-            get { return (collidable != null ? collidable.CollisionFixed : false); }
+            get { return collidable?.CollisionFixed ?? false; }
         }
 
         /// <summary>
@@ -857,7 +852,7 @@ namespace AntMe.Basics.EngineProperties
         /// </summary>
         private float Weight
         {
-            get { return (portable != null ? portable.PortableWeight : 0f); }
+            get { return portable?.PortableWeight ?? 0f; }
         }
 
         /// <summary>
@@ -865,7 +860,7 @@ namespace AntMe.Basics.EngineProperties
         /// </summary>
         private float Strength
         {
-            get { return (carrier != null ? carrier.CarrierStrength : 0f); }
+            get { return carrier?.CarrierStrength ?? 0f; }
         }
 
         /// <summary>
@@ -875,9 +870,7 @@ namespace AntMe.Basics.EngineProperties
         {
             get
             {
-                if (load != null)
-                    return load.AppliedVelocity;
-                return clusterVelocity;
+                return load?.AppliedVelocity ?? clusterVelocity;
             }
         }
 
@@ -888,9 +881,7 @@ namespace AntMe.Basics.EngineProperties
         {
             get
             {
-                if (load != null)
-                    return load.AppliedMass;
-                return clusterMass;
+                return load?.AppliedMass ?? clusterMass;
             }
         }
 

--- a/src/AntMe.Basics/FactionProperties/PointsProperty.cs
+++ b/src/AntMe.Basics/FactionProperties/PointsProperty.cs
@@ -157,8 +157,7 @@ namespace AntMe.Basics.FactionProperties
                 Where(p => p.EnablePoints && p.PointsCategory.Equals(category)).
                 Sum(p => p.Points);
             pointsPerCategory[category] = value;
-            if (OnCategoryPointsChanged != null)
-                OnCategoryPointsChanged(category, value);
+            OnCategoryPointsChanged?.Invoke(category, value);
         }
 
         /// <summary>
@@ -175,8 +174,7 @@ namespace AntMe.Basics.FactionProperties
             private set
             {
                 points = value;
-                if (OnPointsChanged != null)
-                    OnPointsChanged(value);
+                OnPointsChanged?.Invoke(value);
             }
         }
 

--- a/src/AntMe.Basics/Factions/Ants/AntFactoryInterop.cs
+++ b/src/AntMe.Basics/Factions/Ants/AntFactoryInterop.cs
@@ -16,9 +16,7 @@ namespace AntMe.Basics.Factions.Ants
 
         internal Type RequestCreateMember()
         {
-            if (OnCreateMember != null)
-                return OnCreateMember();
-            return null;
+            return OnCreateMember?.Invoke();
         }
 
         public event CreateMember OnCreateMember;

--- a/src/AntMe.Basics/Factions/Ants/AntUnitInterop.cs
+++ b/src/AntMe.Basics/Factions/Ants/AntUnitInterop.cs
@@ -44,8 +44,7 @@ namespace AntMe.Basics.Factions.Ants
             markerDelay = Math.Max(0, markerDelay - 1);
 
             // Tick ausführen
-            if (Tick != null)
-                Tick();
+            Tick?.Invoke();
         }
 
         /// <summary>
@@ -79,7 +78,7 @@ namespace AntMe.Basics.Factions.Ants
         /// <summary>
         /// Returns the Caste Name for this Item.
         /// </summary>
-        public string Caste { get { return Item.Attributes != null ? Item.Attributes.Name : string.Empty; } }
+        public string Caste { get { return Item.Attributes?.Name ?? string.Empty; } }
 
         #endregion
 

--- a/src/AntMe.Basics/Factions/Ants/Interop/AntMovementInterop.cs
+++ b/src/AntMe.Basics/Factions/Ants/Interop/AntMovementInterop.cs
@@ -91,8 +91,7 @@ namespace AntMe.Basics.Factions.Ants.Interop
                 {
                     // Alles anhalten und Reach melden
                     Stop();
-                    if (OnTargetReched != null)
-                        OnTargetReched(i.GetItemInfo(Item));
+                    OnTargetReched?.Invoke(i.GetItemInfo(Item));
                 }
             };
         }
@@ -107,14 +106,14 @@ namespace AntMe.Basics.Factions.Ants.Interop
                 else
                     item.Orientation = item.Orientation.InvertX();
             }
-            if (OnHitWall != null) OnHitWall(direction);
+            OnHitWall?.Invoke(direction);
         }
 
         protected override void Update(int round)
         {
             // Sollten Kollisionen passiert sein, Event werfen
-            if (OnCollision != null && collidedItems.Count > 0)
-                OnCollision();
+            if (collidedItems.Count > 0)
+                OnCollision?.Invoke();
 
             collidedItems.Clear();
 
@@ -174,7 +173,7 @@ namespace AntMe.Basics.Factions.Ants.Interop
             else
             {
                 // Kein Ziel
-                if (OnWaits != null) OnWaits();
+                OnWaits?.Invoke();
             }
         }
 

--- a/src/AntMe.Basics/Factions/Ants/Interop/InteractionInterop.cs
+++ b/src/AntMe.Basics/Factions/Ants/Interop/InteractionInterop.cs
@@ -56,14 +56,12 @@ namespace AntMe.Basics.Factions.Ants.Interop
 
             attackable.OnKill += i =>
             {
-                if (OnKill != null)
-                    OnKill();
+                OnKill?.Invoke();
             };
 
             attackable.OnAttackerHit += (i, value) =>
             {
-                if (OnHit != null)
-                    OnHit(value);
+                OnHit?.Invoke(value);
             };
 
             attackable.OnNewAttackerItem += i =>
@@ -279,7 +277,7 @@ namespace AntMe.Basics.Factions.Ants.Interop
         {
             get
             {
-                return attacker.AttackTarget != null ? attacker.AttackTarget.Item.GetItemInfo(Item) : null;
+                return attacker.AttackTarget?.Item.GetItemInfo(Item);
             }
         }
 
@@ -315,8 +313,7 @@ namespace AntMe.Basics.Factions.Ants.Interop
         {
             get
             {
-                if (carrier.CarrierLoad == null) return null;
-                return carrier.CarrierLoad.Item.GetItemInfo(Item);
+                return carrier.CarrierLoad?.Item.GetItemInfo(Item);
             }
         }
 

--- a/src/AntMe.Basics/Factions/Ants/Interop/RecognitionInterop.cs
+++ b/src/AntMe.Basics/Factions/Ants/Interop/RecognitionInterop.cs
@@ -69,20 +69,19 @@ namespace AntMe.Basics.Factions.Ants.Interop
             // Set new Environment on Cell Switch
             sighting.OnEnvironmentChanged += (i, value) =>
             {
-                if (OnEnvironmentChanged != null)
-                    OnEnvironmentChanged(value);
+                OnEnvironmentChanged?.Invoke(value);
             };
         }
 
         protected override void Update(int round)
         {
             // Visible prüfen
-            if (Spots != null && visibleItems.Count > 0)
-                Spots();
+            if (visibleItems.Count > 0)
+                Spots?.Invoke();
 
             // Smellable prüfen
-            if (Smells != null && smellableItems.Count > 0)
-                Smells();
+            if (smellableItems.Count > 0)
+                Smells?.Invoke();
         }
 
         #region Properties

--- a/src/AntMe.Basics/Factions/Bugs/BugFactoryInterop.cs
+++ b/src/AntMe.Basics/Factions/Bugs/BugFactoryInterop.cs
@@ -12,9 +12,7 @@ namespace AntMe.Basics.Factions.Bugs
 
         internal Type RequestCreateMember()
         {
-            if (OnCreateMember != null)
-                return OnCreateMember();
-            return null;
+            return OnCreateMember?.Invoke();
         }
 
         public event CreateMember OnCreateMember;

--- a/src/AntMe.Basics/Factions/DeathCountProperty.cs
+++ b/src/AntMe.Basics/Factions/DeathCountProperty.cs
@@ -116,8 +116,7 @@ namespace AntMe.Basics.Factions
             set
             {
                 enabled = value;
-                if (OnEnablePointsChanged != null)
-                    OnEnablePointsChanged(this, value);
+                OnEnablePointsChanged?.Invoke(this, value);
             }
         }
 
@@ -135,8 +134,7 @@ namespace AntMe.Basics.Factions
             private set
             {
                 points = value;
-                if (OnPointsChanged != null)
-                    OnPointsChanged(this, value);
+                OnPointsChanged?.Invoke(this, value);
             }
         }
 
@@ -149,8 +147,7 @@ namespace AntMe.Basics.Factions
             set
             {
                 removedItemsCount = value;
-                if (OnRemovedItemCountChanged != null)
-                    OnRemovedItemCountChanged(value);
+                OnRemovedItemCountChanged?.Invoke(value);
             }
         }
 
@@ -163,8 +160,7 @@ namespace AntMe.Basics.Factions
             set
             {
                 killedItemsCount = value;
-                if (OnKilledItemCountChanged != null)
-                    OnKilledItemCountChanged(value);
+                OnKilledItemCountChanged?.Invoke(value);
             }
         }
 
@@ -177,8 +173,7 @@ namespace AntMe.Basics.Factions
             set
             {
                 damageCount = value;
-                if (OnKilledItemCountChanged != null)
-                    OnDamageCountChanged(value);
+                OnDamageCountChanged?.Invoke(value);
             }
         }
 

--- a/src/AntMe.Basics/ItemProperties/AttackableProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/AttackableProperty.cs
@@ -33,8 +33,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 attackableHealth = Math.Max(0, value);
-                if (OnAttackableHealthChanged != null)
-                    OnAttackableHealthChanged(Item, attackableHealth);
+                OnAttackableHealthChanged?.Invoke(Item, attackableHealth);
             }
         }
 
@@ -47,8 +46,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 attackableMaximumHealth = Math.Max(0, value);
-                if (OnAttackableMaximumHealthChanged != null)
-                    OnAttackableMaximumHealthChanged(Item, attackableMaximumHealth);
+                OnAttackableMaximumHealthChanged?.Invoke(Item, attackableMaximumHealth);
             }
         }
 
@@ -69,8 +67,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 attackableRadius = Math.Max(value, 0f);
-                if (OnAttackableRadiusChanged != null)
-                    OnAttackableRadiusChanged(Item, attackableRadius);
+                OnAttackableRadiusChanged?.Invoke(Item, attackableRadius);
             }
         }
 
@@ -85,8 +82,7 @@ namespace AntMe.Basics.ItemProperties
             if (!attackerItems.Contains(item))
             {
                 attackerItems.Add(item);
-                if (OnNewAttackerItem != null)
-                    OnNewAttackerItem(item);
+                OnNewAttackerItem?.Invoke(item);
             }
         }
 
@@ -98,8 +94,7 @@ namespace AntMe.Basics.ItemProperties
         {
             if (attackerItems.Remove(item))
             {
-                if (OnLostAttackerItem != null)
-                    OnLostAttackerItem(item);
+                OnLostAttackerItem?.Invoke(item);
             }
         }
 
@@ -109,8 +104,7 @@ namespace AntMe.Basics.ItemProperties
         /// <param name="item">Attacker</param>
         internal void NoteAttackerItem(AttackerProperty item)
         {
-            if (OnAttackerItem != null)
-                OnAttackerItem(item);
+            OnAttackerItem?.Invoke(item);
         }
 
         /// <summary>
@@ -120,8 +114,7 @@ namespace AntMe.Basics.ItemProperties
         /// <param name="hitpoints">Hitpoints</param>
         internal void AttackerHit(AttackerProperty item, int hitpoints)
         {
-            if (OnAttackerHit != null)
-                OnAttackerHit(item.Item, hitpoints);
+            OnAttackerHit?.Invoke(item.Item, hitpoints);
         }
 
         /// <summary>
@@ -129,8 +122,7 @@ namespace AntMe.Basics.ItemProperties
         /// </summary>
         internal void Kill()
         {
-            if (OnKill != null)
-                OnKill(Item);
+            OnKill?.Invoke(Item);
         }
 
         #endregion

--- a/src/AntMe.Basics/ItemProperties/AttackerProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/AttackerProperty.cs
@@ -49,8 +49,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 attackRange = Math.Max(value, 0f);
-                if (OnAttackRangeChanged != null)
-                    OnAttackRangeChanged(Item, attackRange);
+                OnAttackRangeChanged?.Invoke(Item, attackRange);
             }
         }
 
@@ -63,8 +62,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 attackRecoveryTime = Math.Max(value, 0);
-                if (OnAttackRecoveryTimeChanged != null)
-                    OnAttackRecoveryTimeChanged(Item, attackRecoveryTime);
+                OnAttackRecoveryTimeChanged?.Invoke(Item, attackRecoveryTime);
             }
         }
 
@@ -77,8 +75,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 attackStrength = Math.Max(value, 0);
-                if (OnAttackStrengthChanged != null)
-                    OnAttackStrengthChanged(Item, attackStrength);
+                OnAttackStrengthChanged?.Invoke(Item, attackStrength);
             }
         }
 
@@ -91,8 +88,7 @@ namespace AntMe.Basics.ItemProperties
             private set
             {
                 attackTarget = value;
-                if (OnAttackTargetChanged != null)
-                    OnAttackTargetChanged(Item, value);
+                OnAttackTargetChanged?.Invoke(Item, value);
             }
         }
 
@@ -105,8 +101,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 damageCounter = value;
-                if (OnDamageCounterChanged != null)
-                    OnDamageCounterChanged(Item, value);
+                OnDamageCounterChanged?.Invoke(Item, value);
             }
         }
 
@@ -119,8 +114,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 killCounter = value;
-                if (OnKillCounterChanged != null)
-                    OnKillCounterChanged(Item, value);
+                OnKillCounterChanged?.Invoke(Item, value);
             }
         }
 
@@ -133,8 +127,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 points = value;
-                if (OnPointsChanged != null)
-                    OnPointsChanged(this, value);
+                OnPointsChanged?.Invoke(this, value);
             }
         }
 
@@ -147,8 +140,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 enablePoints = value;
-                if (OnEnablePointsChanged != null)
-                    OnEnablePointsChanged(this, value);
+                OnEnablePointsChanged?.Invoke(this, value);
             }
         }
 
@@ -178,8 +170,7 @@ namespace AntMe.Basics.ItemProperties
             // TODO: Create Settings
             Points = AttackDamageCounter + (100 * AttackKillCounter);
 
-            if (OnAttackHit != null)
-                OnAttackHit(item.Item, hitpoints);
+            OnAttackHit?.Invoke(item.Item, hitpoints);
         }
 
         #endregion

--- a/src/AntMe.Basics/ItemProperties/CarrierProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/CarrierProperty.cs
@@ -25,8 +25,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 carrierStrength = Math.Max(value, 0f);
-                if (OnCarrierStrengthChanged != null)
-                    OnCarrierStrengthChanged(Item, carrierStrength);
+                OnCarrierStrengthChanged?.Invoke(Item, carrierStrength);
             }
         }
 
@@ -39,8 +38,7 @@ namespace AntMe.Basics.ItemProperties
             private set
             {
                 carrierLoad = value;
-                if (OnCarrierLoadChanged != null)
-                    OnCarrierLoadChanged(Item, value);
+                OnCarrierLoadChanged?.Invoke(Item, value);
             }
         }
 
@@ -95,11 +93,8 @@ namespace AntMe.Basics.ItemProperties
         /// </summary>
         public void Drop()
         {
-            if (carrierLoad != null)
-            {
-                carrierLoad.RemoveCarrier(this);
-                CarrierLoad = null;
-            }
+            carrierLoad?.RemoveCarrier(this);
+            CarrierLoad = null;
         }
 
         /// <summary>

--- a/src/AntMe.Basics/ItemProperties/CollectableProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/CollectableProperty.cs
@@ -27,8 +27,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 collectableRadius = Math.Max(value, 0f);
-                if (OnCollectableRadiusChanged != null)
-                    OnCollectableRadiusChanged(Item, collectableRadius);
+                OnCollectableRadiusChanged?.Invoke(Item, collectableRadius);
             }
         }
 
@@ -46,8 +45,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 enabled = value;
-                if (OnEnablePointsChanged != null)
-                    OnEnablePointsChanged(this, enabled);
+                OnEnablePointsChanged?.Invoke(this, enabled);
             }
         }
 
@@ -65,8 +63,7 @@ namespace AntMe.Basics.ItemProperties
             protected set
             {
                 points = value;
-                if (OnPointsChanged != null)
-                    OnPointsChanged(this, points);
+                OnPointsChanged?.Invoke(this, points);
             }
         }
 

--- a/src/AntMe.Basics/ItemProperties/CollectorProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/CollectorProperty.cs
@@ -24,8 +24,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 collectorRange = Math.Max(value, 0f);
-                if (OnCollectorRangeChanged != null)
-                    OnCollectorRangeChanged(Item, collectorRange);
+                OnCollectorRangeChanged?.Invoke(Item, collectorRange);
             }
         }
 

--- a/src/AntMe.Basics/ItemProperties/CollidableProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/CollidableProperty.cs
@@ -42,8 +42,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 collisionRadius = Math.Max(value, 0f);
-                if (OnCollisionRadiusChanged != null)
-                    OnCollisionRadiusChanged(Item, collisionRadius);
+                OnCollisionRadiusChanged?.Invoke(Item, collisionRadius);
             }
         }
 
@@ -56,8 +55,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 collisionMass = Math.Max(value, 0f);
-                if (OnCollisionMassChanged != null)
-                    OnCollisionMassChanged(Item, collisionMass);
+                OnCollisionMassChanged?.Invoke(Item, collisionMass);
             }
         }
 
@@ -70,8 +68,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 collisionFixed = value;
-                if (OnCollisionFixedChanged != null)
-                    OnCollisionFixedChanged(Item, value);
+                OnCollisionFixedChanged?.Invoke(Item, value);
             }
         }
 
@@ -83,8 +80,7 @@ namespace AntMe.Basics.ItemProperties
         /// <param name="item">Colliding Item</param>
         internal void CollideItem(Item item)
         {
-            if (OnCollision != null)
-                OnCollision(Item, item);
+            OnCollision?.Invoke(Item, item);
         }
 
         #endregion

--- a/src/AntMe.Basics/ItemProperties/GoodsProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/GoodsProperty.cs
@@ -24,8 +24,7 @@ namespace AntMe.Basics.ItemProperties
                 if (Amount > capacity)
                     Amount = Math.Min(capacity, Amount);
 
-                if (OnCapacityChanged != null)
-                    OnCapacityChanged(Item, capacity);
+                OnCapacityChanged?.Invoke(Item, capacity);
             }
         }
 
@@ -39,8 +38,7 @@ namespace AntMe.Basics.ItemProperties
             {
                 // Cap to Capacity.
                 amount = Math.Min(Capacity, Math.Max(0, value));
-                if (OnAmountChanged != null)
-                    OnAmountChanged(Item, amount);
+                OnAmountChanged?.Invoke(Item, amount);
             }
         }
 

--- a/src/AntMe.Basics/ItemProperties/PortableProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/PortableProperty.cs
@@ -40,8 +40,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 portableRadius = Math.Max(value, 0f);
-                if (OnPortableRadiusChanged != null)
-                    OnPortableRadiusChanged(Item, portableRadius);
+                OnPortableRadiusChanged?.Invoke(Item, portableRadius);
             }
         }
 
@@ -54,8 +53,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 portableWeight = Math.Max(value, 0f);
-                if (OnPortableWeightChanged != null)
-                    OnPortableWeightChanged(Item, portableWeight);
+                OnPortableWeightChanged?.Invoke(Item, portableWeight);
             }
         }
 
@@ -71,8 +69,7 @@ namespace AntMe.Basics.ItemProperties
                 return;
 
             carrierItems.Add(carrier);
-            if (OnNewCarrierItem != null)
-                OnNewCarrierItem(carrier);
+            OnNewCarrierItem?.Invoke(carrier);
         }
 
         /// <summary>
@@ -85,8 +82,7 @@ namespace AntMe.Basics.ItemProperties
                 return;
 
             carrierItems.Remove(carrier);
-            if (OnLostCarrierItem != null)
-                OnLostCarrierItem(carrier);
+            OnLostCarrierItem?.Invoke(carrier);
         }
 
         #endregion

--- a/src/AntMe.Basics/ItemProperties/SightingProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/SightingProperty.cs
@@ -30,8 +30,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 viewrange = Math.Max(0f, value);
-                if (OnViewRangeChanged != null)
-                    OnViewRangeChanged(Item, viewrange);
+                OnViewRangeChanged?.Invoke(Item, viewrange);
             }
         }
 
@@ -44,8 +43,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 viewDirection = value;
-                if (OnViewDirectionChanged != null)
-                    OnViewDirectionChanged(Item, value);
+                OnViewDirectionChanged?.Invoke(Item, value);
             }
         }
 
@@ -61,8 +59,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 viewangle = Math.Max(0f, Math.Min(360, value));
-                if (OnViewAngleChanged != null)
-                    OnViewAngleChanged(Item, viewangle);
+                OnViewAngleChanged?.Invoke(Item, viewangle);
             }
         }
 
@@ -94,8 +91,7 @@ namespace AntMe.Basics.ItemProperties
             {
                 visibleItems.Add(item);
 
-                if (OnNewVisibleItem != null)
-                    OnNewVisibleItem(item);
+                OnNewVisibleItem?.Invoke(item);
             }
         }
 
@@ -109,8 +105,7 @@ namespace AntMe.Basics.ItemProperties
             {
                 visibleItems.Remove(item);
 
-                if (OnLostVisibleItem != null)
-                    OnLostVisibleItem(item);
+                OnLostVisibleItem?.Invoke(item);
             }
         }
 
@@ -120,8 +115,7 @@ namespace AntMe.Basics.ItemProperties
         /// <param name="item">Visible Item</param>
         internal void NoteVisibleItem(VisibleProperty item)
         {
-            if (OnVisibleItem != null)
-                OnVisibleItem(item);
+            OnVisibleItem?.Invoke(item);
         }
 
         /// <summary>
@@ -149,13 +143,12 @@ namespace AntMe.Basics.ItemProperties
                     {
                         // Get Cell Infos
                         MapTile tile = map[cell.X, cell.Y];
-                        Environment[offset.X, offset.Y] = tile != null ? tile.GetInfo(item) : null;
+                        Environment[offset.X, offset.Y] = tile?.GetInfo(item);
                     }
                 }
             }
 
-            if (OnEnvironmentChanged != null)
-                OnEnvironmentChanged(Item, Environment);
+            OnEnvironmentChanged?.Invoke(Item, Environment);
         }
 
         #endregion

--- a/src/AntMe.Basics/ItemProperties/SmellableProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/SmellableProperty.cs
@@ -40,8 +40,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 smellableRadius = Math.Max(0f, value);
-                if (OnSmellableRadiusChanged != null)
-                    OnSmellableRadiusChanged(Item, smellableRadius);
+                OnSmellableRadiusChanged?.Invoke(Item, smellableRadius);
             }
         }
 
@@ -59,8 +58,7 @@ namespace AntMe.Basics.ItemProperties
             {
                 snifferItems.Add(item);
 
-                if (OnNewSnifferItem != null)
-                    OnNewSnifferItem(item);
+                OnNewSnifferItem?.Invoke(item);
             }
         }
 
@@ -72,8 +70,7 @@ namespace AntMe.Basics.ItemProperties
         {
             if (snifferItems.Remove(item))
             {
-                if (OnLostSnifferItem != null)
-                    OnLostSnifferItem(item);
+                OnLostSnifferItem?.Invoke(item);
             }
         }
 

--- a/src/AntMe.Basics/ItemProperties/SnifferProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/SnifferProperty.cs
@@ -36,8 +36,7 @@ namespace AntMe.Basics.ItemProperties
             {
                 smellableItems.Add(item);
 
-                if (OnNewSmellableItem != null)
-                    OnNewSmellableItem(item);
+                OnNewSmellableItem?.Invoke(item);
             }
         }
 
@@ -49,8 +48,7 @@ namespace AntMe.Basics.ItemProperties
         {
             if (smellableItems.Remove(item))
             {
-                if (OnLostSmellableItem != null)
-                    OnLostSmellableItem(item);
+                OnLostSmellableItem?.Invoke(item);
             }
         }
 
@@ -60,8 +58,7 @@ namespace AntMe.Basics.ItemProperties
         /// <param name="item">Sniffed Item</param>
         internal void NoteSmellableItem(SmellableProperty item)
         {
-            if (OnSmellableItem != null)
-                OnSmellableItem(item);
+            OnSmellableItem?.Invoke(item);
         }
 
         #endregion

--- a/src/AntMe.Basics/ItemProperties/VisibleProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/VisibleProperty.cs
@@ -31,8 +31,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 visibilityRadius = Math.Max(0f, value);
-                if (OnVisibilityRadiusChanged != null)
-                    OnVisibilityRadiusChanged(Item, visibilityRadius);
+                OnVisibilityRadiusChanged?.Invoke(Item, visibilityRadius);
             }
         }
 
@@ -57,8 +56,7 @@ namespace AntMe.Basics.ItemProperties
             {
                 sightingItems.Add(item);
 
-                if (OnNewSightingItem != null)
-                    OnNewSightingItem(item);
+                OnNewSightingItem?.Invoke(item);
             }
         }
 
@@ -73,8 +71,7 @@ namespace AntMe.Basics.ItemProperties
             {
                 sightingItems.Remove(item);
 
-                if (OnLostSightingItem != null)
-                    OnLostSightingItem(item);
+                OnLostSightingItem?.Invoke(item);
             }
         }
 

--- a/src/AntMe.Basics/ItemProperties/WalkingProperty.cs
+++ b/src/AntMe.Basics/ItemProperties/WalkingProperty.cs
@@ -32,8 +32,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 direction = value;
-                if (OnMoveDirectionChanged != null)
-                    OnMoveDirectionChanged(Item, direction);
+                OnMoveDirectionChanged?.Invoke(Item, direction);
             }
         }
 
@@ -46,8 +45,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 speed = Math.Max(value, 0f);
-                if (OnMoveSpeedChanged != null)
-                    OnMoveSpeedChanged(Item, speed);
+                OnMoveSpeedChanged?.Invoke(Item, speed);
             }
         }
 
@@ -60,8 +58,7 @@ namespace AntMe.Basics.ItemProperties
             set
             {
                 maxSpeed = Math.Max(value, 0f);
-                if (OnMaximumMoveSpeedChanged != null)
-                    OnMaximumMoveSpeedChanged(Item, maxSpeed);
+                OnMaximumMoveSpeedChanged?.Invoke(Item, maxSpeed);
             }
         }
 
@@ -81,8 +78,7 @@ namespace AntMe.Basics.ItemProperties
         /// <param name="direction">Direction</param>
         internal void HitWall(Compass direction)
         {
-            if (OnHitWall != null)
-                OnHitWall(Item, direction);
+            OnHitWall?.Invoke(Item, direction);
         }
 
         /// <summary>
@@ -91,8 +87,7 @@ namespace AntMe.Basics.ItemProperties
         /// <param name="direction">Direction</param>
         internal void HitBorder(Compass direction)
         {
-            if (OnHitBorder != null)
-                OnHitBorder(Item, direction);
+            OnHitBorder?.Invoke(Item, direction);
         }
 
         #endregion

--- a/src/AntMe.Basics/LevelProperties/AreaTrigger.cs
+++ b/src/AntMe.Basics/LevelProperties/AreaTrigger.cs
@@ -108,8 +108,7 @@ namespace AntMe.Basics.LevelProperties
                     item.Position.Y <= LowerRight.Y)
                 {
                     hit = true;
-                    if (OnItemTrapped != null)
-                        OnItemTrapped(this, item);
+                    OnItemTrapped?.Invoke(this, item);
                 }
             }
             return hit;

--- a/src/AntMe.Basics/LevelProperties/TimerTrigger.cs
+++ b/src/AntMe.Basics/LevelProperties/TimerTrigger.cs
@@ -43,8 +43,7 @@
         {
             if (Enabled && level.Engine.Round == TargetTime)
             {
-                if (OnTimeReached != null)
-                    OnTimeReached(this);
+                OnTimeReached?.Invoke(this);
                 return true;
             }
             return false;

--- a/src/AntMe.Core/Engine.cs
+++ b/src/AntMe.Core/Engine.cs
@@ -147,8 +147,7 @@ namespace AntMe
                 PrivateRemoveItem(removeQueue.Dequeue());
 
             // Inform about another Round
-            if (OnNextRound != null)
-                OnNextRound(Round);
+            OnNextRound?.Invoke(Round);
         }
 
         /// <summary>
@@ -186,8 +185,7 @@ namespace AntMe
             NormalizeItemPosition(item);
 
             // Inform about a new Item
-            if (OnInsertItem != null)
-                OnInsertItem(item);
+            OnInsertItem?.Invoke(item);
         }
 
         /// <summary>
@@ -199,8 +197,7 @@ namespace AntMe
             if (items.Contains(item))
             {
                 // Inform about removed Item
-                if (OnRemoveItem != null)
-                    OnRemoveItem(item);
+                OnRemoveItem?.Invoke(item);
 
                 // Remove Item from internal Lists
                 items.Remove(item);

--- a/src/AntMe.Core/Item.cs
+++ b/src/AntMe.Core/Item.cs
@@ -124,8 +124,7 @@ namespace AntMe
                 if (cell != value)
                 {
                     cell = value;
-                    if (CellChanged != null)
-                        CellChanged(this, value);
+                    CellChanged?.Invoke(this, value);
                 }
             }
         }
@@ -139,8 +138,7 @@ namespace AntMe
             set
             {
                 orientation = value;
-                if (OrientationChanged != null)
-                    OrientationChanged(this, value);
+                OrientationChanged?.Invoke(this, value);
             }
         }
 
@@ -156,8 +154,7 @@ namespace AntMe
             set
             {
                 radius = value;
-                if (RadiusChanged != null)
-                    RadiusChanged(this, value);
+                RadiusChanged?.Invoke(this, value);
             }
         }
 
@@ -178,8 +175,7 @@ namespace AntMe
                         Cell = Engine.Map.GetCellIndex(value);
 
                     //InvalidateDistances();
-                    if (PositionChanged != null)
-                        PositionChanged(this, value);
+                    PositionChanged?.Invoke(this, value);
                 }
             }
         }
@@ -282,8 +278,7 @@ namespace AntMe
             this.id = id;
 
             OnInsert();
-            if (Inserted != null)
-                Inserted(this);
+            Inserted?.Invoke(this);
         }
 
         /// <summary>
@@ -292,8 +287,7 @@ namespace AntMe
         internal void InternalRemoveEngine()
         {
             OnRemoved();
-            if (Removed != null)
-                Removed(this);
+            Removed?.Invoke(this);
 
             engine = null;
             id = 0;

--- a/src/AntMe.Core/KeyValueStore.cs
+++ b/src/AntMe.Core/KeyValueStore.cs
@@ -704,7 +704,7 @@ namespace AntMe
                         description = string.Empty;
                     else
                         description += VDE.Description;
-                    sw.WriteLine("{0}={1}{2}", key.ToString().PadRight(keyLength), (VDE.Value != null ? VDE.Value.ToString(CultureInfo.InvariantCulture) : "").PadRight(valueLength), description);
+                    sw.WriteLine("{0}={1}{2}", key.ToString().PadRight(keyLength), (VDE.Value?.ToString(CultureInfo.InvariantCulture) ?? "").PadRight(valueLength), description);
                 }
                 sw.WriteLine();
 

--- a/src/AntMe.Core/Level.cs
+++ b/src/AntMe.Core/Level.cs
@@ -406,10 +406,7 @@ namespace AntMe
             // Updates der Factions
             for (int i = 0; i < MAX_SLOTS; i++)
             {
-                if (Factions[i] != null)
-                {
-                    Factions[i].Update(engine.Round);
-                }
+                Factions[i]?.Update(engine.Round);
             }
 
             try

--- a/src/AntMe.Core/MapMaterial.cs
+++ b/src/AntMe.Core/MapMaterial.cs
@@ -43,8 +43,7 @@ namespace AntMe
             protected set
             {
                 speed = value;
-                if (OnSpeedChanged != null)
-                    OnSpeedChanged(value);
+                OnSpeedChanged?.Invoke(value);
             }
         }
 

--- a/src/AntMe.Core/MapTile.cs
+++ b/src/AntMe.Core/MapTile.cs
@@ -88,8 +88,7 @@ namespace AntMe
             set
             {
                 material = value;
-                if (OnMaterialChanged != null)
-                    OnMaterialChanged(value);
+                OnMaterialChanged?.Invoke(value);
             }
         }
 
@@ -104,8 +103,7 @@ namespace AntMe
             set
             {
                 orientation = value;
-                if (OnOrientationChanged != null)
-                    OnOrientationChanged(value);
+                OnOrientationChanged?.Invoke(value);
             }
         }
 
@@ -120,8 +118,7 @@ namespace AntMe
             set
             {
                 heightLevel = value;
-                if (OnHeightLevelChanged != null)
-                    OnHeightLevelChanged(value);
+                OnHeightLevelChanged?.Invoke(value);
             }
         }
 

--- a/src/AntMe.Core/Serialization/LevelStateByteSerializer.cs
+++ b/src/AntMe.Core/Serialization/LevelStateByteSerializer.cs
@@ -57,17 +57,11 @@ namespace AntMe.Serialization
         /// </summary>
         public void Dispose()
         {
-            if (serializer != null)
-            {
-                serializer.Dispose();
-                serializer = null;
-            }
+            serializer?.Dispose();
+            serializer = null;
 
-            if (stream != null)
-            {
-                stream.Dispose();
-                stream = null;
-            }
+            stream?.Dispose();
+            stream = null;
         }
     }
 }

--- a/src/AntMe.Core/Serialization/LevelStateSerializer.cs
+++ b/src/AntMe.Core/Serialization/LevelStateSerializer.cs
@@ -193,31 +193,17 @@ namespace AntMe.Serialization
         /// </summary>
         public void Dispose()
         {
-            if (writer != null)
-            {
-                writer.Dispose();
-                writer = null;
-            }
+            writer?.Dispose();
+            writer = null;
 
-            if (reader != null)
-            {
-                reader.Dispose();
-                reader = null;
-            }
+            reader?.Dispose();
+            reader = null;
 
-            if (serializer != null)
-            {
-                serializer.Dispose();
-                serializer = null;
-            }
+            serializer?.Dispose();
+            serializer = null;
 
-            if (deserializer != null)
-            {
-                deserializer.Dispose();
-                deserializer = null;
-            }
+            deserializer?.Dispose();
+            deserializer = null;
         }
-
-        
     }
 }

--- a/src/AntMe.Runtime/Communication/LocalSimulationClient.cs
+++ b/src/AntMe.Runtime/Communication/LocalSimulationClient.cs
@@ -149,8 +149,7 @@ namespace AntMe.Runtime.Communication
         /// <param name="ex"></param>
         public void CloseByError(Exception ex)
         {
-            if (OnError != null)
-                OnError(this, ex.Message);
+            OnError?.Invoke(this, ex.Message);
         }
 
         /// <summary>
@@ -240,8 +239,7 @@ namespace AntMe.Runtime.Communication
         /// <param name="message">Nachricht</param>
         public void SendMessage(string message)
         {
-            if (OnMessageReceived != null)
-                OnMessageReceived(this, master, message);
+            OnMessageReceived?.Invoke(this, master, message);
         }
 
         public event SimulationClientDelegate<UserProfile, string> OnMessageReceived;
@@ -271,8 +269,7 @@ namespace AntMe.Runtime.Communication
                 ResetSlots();
 
                 // Event werfen
-                if (OnLevelChanged != null)
-                    OnLevelChanged(this, null);
+                OnLevelChanged?.Invoke(this, null);
 
                 return true;
             }
@@ -300,8 +297,7 @@ namespace AntMe.Runtime.Communication
                 }
 
                 // Event werfen
-                if (OnLevelChanged != null)
-                    OnLevelChanged(this, this.level);
+                OnLevelChanged?.Invoke(this, this.level);
 
                 return true;
             }
@@ -351,8 +347,7 @@ namespace AntMe.Runtime.Communication
                 players[slot] = null;
 
                 // Event werfen
-                if (OnPlayerChanged != null)
-                    OnPlayerChanged(this, slot);
+                OnPlayerChanged?.Invoke(this, slot);
 
                 return true;
             }
@@ -379,8 +374,7 @@ namespace AntMe.Runtime.Communication
                 }
 
                 // Event werfen
-                if (OnPlayerChanged != null)
-                    OnPlayerChanged(this, slot);
+                OnPlayerChanged?.Invoke(this, slot);
 
                 return true;
             }
@@ -444,8 +438,7 @@ namespace AntMe.Runtime.Communication
                     {
                         slots[i].ColorKey = oldColor;
 
-                        if (OnPlayerChanged != null)
-                            OnPlayerChanged(this, i);
+                        OnPlayerChanged?.Invoke(this, i);
 
                         break;
                     }
@@ -458,8 +451,7 @@ namespace AntMe.Runtime.Communication
             slots[slot].Team = team;
             slots[slot].ReadyState = ready;
 
-            if (OnPlayerChanged != null)
-                OnPlayerChanged(this, slot);
+            OnPlayerChanged?.Invoke(this, slot);
 
             return true;
         }
@@ -478,8 +470,7 @@ namespace AntMe.Runtime.Communication
             }
 
             // Event werfen
-            if (OnPlayerReset != null)
-                OnPlayerReset(this);
+            OnPlayerReset?.Invoke(this);
         }
 
         /// <summary>
@@ -576,8 +567,7 @@ namespace AntMe.Runtime.Communication
 
             // State ändern
             state = SimulationState.Running;
-            if (OnSimulationChanged != null)
-                OnSimulationChanged(this, state, rate);
+            OnSimulationChanged?.Invoke(this, state, rate);
 
             // Thread erzeugen
             thread = new Thread(SimulationLoop);
@@ -597,8 +587,7 @@ namespace AntMe.Runtime.Communication
             if (state == SimulationState.Running)
             {
                 state = SimulationState.Paused;
-                if (OnSimulationState != null)
-                    OnSimulationChanged(this, state, rate);
+                OnSimulationChanged?.Invoke(this, state, rate);
             }
         }
 
@@ -613,9 +602,7 @@ namespace AntMe.Runtime.Communication
 
             // state melden und setzen
             state = SimulationState.Running;
-            if (OnSimulationState != null)
-                OnSimulationChanged(this, state, rate);
-
+            OnSimulationChanged?.Invoke(this, state, rate);
         }
 
         /// <summary>
@@ -632,8 +619,7 @@ namespace AntMe.Runtime.Communication
             if (thread.Join(2000))
                 thread.Abort();
 
-            if (OnSimulationChanged != null)
-                OnSimulationChanged(this, state, rate);
+            OnSimulationChanged?.Invoke(this, state, rate);
         }
 
         /// <summary>
@@ -644,8 +630,7 @@ namespace AntMe.Runtime.Communication
         {
             rate = Math.Max((byte)1, frames);
 
-            if (OnSimulationChanged != null)
-                OnSimulationChanged(this, state, rate);
+            OnSimulationChanged?.Invoke(this, state, rate);
         }
 
         /// <summary>
@@ -692,8 +677,7 @@ namespace AntMe.Runtime.Communication
             catch (Exception ex)
             {
                 // Event werfen
-                if (OnError != null)
-                    OnError(this, ex.Message);
+                OnError?.Invoke(this, ex.Message);
 
                 // Simulation stoppen
                 StopSimulation();
@@ -723,8 +707,7 @@ namespace AntMe.Runtime.Communication
                     continue;
                 }
 
-                if (OnSimulationState != null)
-                    OnSimulationState(this, currentState);
+                OnSimulationState?.Invoke(this, currentState);
 
                 // Wartezeit zwischen Frames
                 while (state != SimulationState.Stopped &&

--- a/src/AntMe.Runtime/Communication/SimulationServer.cs
+++ b/src/AntMe.Runtime/Communication/SimulationServer.cs
@@ -991,11 +991,8 @@ namespace AntMe.Runtime.Communication
             }
 
             // Dispose Simulation
-            if (simulation != null)
-            {
-                simulation.Dispose();
-                simulation = null;
-            }
+            simulation?.Dispose();
+            simulation = null;
 
             // Inform everybody
             SendSimulationChanged(this.frames);
@@ -1132,9 +1129,9 @@ namespace AntMe.Runtime.Communication
                         }
 
                         // Dispose Serializer on Simulation Shutdown
-                        if (state == SimulationState.Stopped && receiver.Serializer != null)
+                        if (state == SimulationState.Stopped)
                         {
-                            receiver.Serializer.Dispose();
+                            receiver.Serializer?.Dispose();
                             receiver.Serializer = null;
                         }
 

--- a/src/AntMe.Runtime/Communication/WcfSimulationCallback.cs
+++ b/src/AntMe.Runtime/Communication/WcfSimulationCallback.cs
@@ -10,68 +10,57 @@ namespace AntMe.Runtime.Communication
     {
         public void MasterChanged(int id)
         {
-            if (OnMasterChanged != null)
-                OnMasterChanged(id);
+            OnMasterChanged?.Invoke(id);
         }
 
         public void UserlistChanged(UserProfile[] users)
         {
-            if (OnUserlistChanged != null)
-                OnUserlistChanged(users);
+            OnUserlistChanged?.Invoke(users);
         }
 
         public void UserAdded(UserProfile user)
         {
-            if (OnUserAdded != null)
-                OnUserAdded(user);
+            OnUserAdded?.Invoke(user);
         }
 
         public void UserDropped(int id)
         {
-            if (OnUserDropped != null)
-                OnUserDropped(id);
+            OnUserDropped?.Invoke(id);
         }
 
         public void UsernameChanged(UserProfile user)
         {
-            if (OnUsernameChanged != null)
-                OnUsernameChanged(user);
+            OnUsernameChanged?.Invoke(user);
         }
 
         public void MessageReceived(UserProfile sender, string message)
         {
-            if (OnMessageReceived != null)
-                OnMessageReceived(sender, message);
+            OnMessageReceived?.Invoke(sender, message);
         }
 
         public void LevelChanged(TypeInfo level)
         {
-            if (OnLevelChanged != null)
-                OnLevelChanged(level);
+            OnLevelChanged?.Invoke(level);
         }
 
         public void PlayerReset(Slot[] slots)
         {
-            if (OnPlayerReset != null)
-                OnPlayerReset(slots);
+            OnPlayerReset?.Invoke(slots);
         }
 
         public void PlayerChanged(Slot slot)
         {
-            if (OnPlayerChanged != null)
-                OnPlayerChanged(slot);
+            OnPlayerChanged?.Invoke(slot);
         }
 
         public void SimulationChanged(SimulationState state, byte framerate)
         {
-            if (OnSimulationChanged != null)
-                OnSimulationChanged(state, framerate);
+            OnSimulationChanged?.Invoke(state, framerate);
         }
 
         public void SimulationState(byte[] state)
         {
-            if (OnSimulationState != null)
-                OnSimulationState(state);
+            OnSimulationState?.Invoke(state);
         }
 
         public event CallbackDelegate<int> OnMasterChanged;

--- a/src/AntMe.Runtime/Communication/WcfSimulationClient.cs
+++ b/src/AntMe.Runtime/Communication/WcfSimulationClient.cs
@@ -127,8 +127,7 @@ namespace AntMe.Runtime.Communication
         /// <param name="ex"></param>
         public void CloseByError(Exception ex)
         {
-            if (OnError != null)
-                OnError(this, ex.Message);
+            OnError?.Invoke(this, ex.Message);
 
             Close();
         }
@@ -141,13 +140,11 @@ namespace AntMe.Runtime.Communication
             // Try to call the last "Goodbye"
             try
             {
-                if (channel != null)
-                    channel.Goodbye();
+                channel?.Goodbye();
             }
             catch (Exception) { }
 
-            if (OnClose != null)
-                OnClose(this);
+            OnClose?.Invoke(this);
         }
 
         /// <summary>
@@ -600,8 +597,7 @@ namespace AntMe.Runtime.Communication
                 }
             }
 
-            if (OnUsernameChanged != null)
-                OnUsernameChanged(this, user);
+            OnUsernameChanged?.Invoke(this, user);
         }
 
         private void callback_OnUserlistChanged(UserProfile[] parameter)
@@ -612,8 +608,7 @@ namespace AntMe.Runtime.Communication
                 this.users.AddRange(parameter);
             }
 
-            if (OnUserlistChanged != null)
-                OnUserlistChanged(this);
+            OnUserlistChanged?.Invoke(this);
         }
 
         private void callback_OnUserDropped(int id)
@@ -629,8 +624,8 @@ namespace AntMe.Runtime.Communication
                 }
             }
 
-            if (OnUserDropped != null && hit)
-                OnUserDropped(this, id);
+            if (hit)
+                OnUserDropped?.Invoke(this, id);
         }
 
         private void callback_OnUserAdded(UserProfile user)
@@ -646,8 +641,8 @@ namespace AntMe.Runtime.Communication
                 }
             }
 
-            if (OnUserAdded != null && hit)
-                OnUserAdded(this, user);
+            if (hit)
+                OnUserAdded?.Invoke(this, user);
         }
 
         private void callback_OnSimulationState(byte[] parameter)
@@ -662,8 +657,7 @@ namespace AntMe.Runtime.Communication
             // Set latest Main State
             _currentState = _deserializer.Deserialize(parameter);
 
-            if (OnSimulationState != null)
-                OnSimulationState(this, _currentState);
+            OnSimulationState?.Invoke(this, _currentState);
         }
 
         private void callback_OnSimulationChanged(SimulationState state, byte framerate)
@@ -672,11 +666,8 @@ namespace AntMe.Runtime.Communication
             if (_serverState != SimulationState.Stopped && state == SimulationState.Stopped)
             {
                 // Trash Deserializer
-                if (_deserializer != null)
-                {
-                    _deserializer.Dispose();
-                    _deserializer = null;
-                }
+                _deserializer?.Dispose();
+                _deserializer = null;
                 
                 // Remove last State
                 _currentState = null;
@@ -696,8 +687,7 @@ namespace AntMe.Runtime.Communication
             _rate = framerate;
 
             // Drop Event
-            if (OnSimulationChanged != null)
-                OnSimulationChanged(this, state, framerate);
+            OnSimulationChanged?.Invoke(this, state, framerate);
         }
 
         private void callback_OnPlayerReset(Slot[] parameter)
@@ -714,8 +704,7 @@ namespace AntMe.Runtime.Communication
                 slots[slot.Id].Team = slot.Team;
             }
 
-            if (OnPlayerReset != null)
-                OnPlayerReset(this);
+            OnPlayerReset?.Invoke(this);
         }
 
         private void callback_OnPlayerChanged(Slot slot)
@@ -729,23 +718,20 @@ namespace AntMe.Runtime.Communication
                 hit.ReadyState = slot.ReadyState;
                 hit.Team = slot.Team;
 
-                if (OnPlayerChanged != null)
-                    OnPlayerChanged(this, hit.Id);
+                OnPlayerChanged?.Invoke(this, hit.Id);
             }
         }
 
         private void callback_OnMessageReceived(UserProfile sender, string message)
         {
-            if (OnMessageReceived != null)
-                OnMessageReceived(this, sender, message);
+            OnMessageReceived?.Invoke(this, sender, message);
         }
 
         private void callback_OnMasterChanged(int id)
         {
             masterId = id;
 
-            if (OnMasterChanged != null)
-                OnMasterChanged(this, Master);
+            OnMasterChanged?.Invoke(this, Master);
         }
 
         private void callback_OnLevelChanged(TypeInfo level)
@@ -756,8 +742,7 @@ namespace AntMe.Runtime.Communication
 
             _level = levelInfo;
 
-            if (OnLevelChanged != null)
-                OnLevelChanged(this, levelInfo);
+            OnLevelChanged?.Invoke(this, levelInfo);
         }
 
         #endregion

--- a/src/AntMe.Runtime/EventLog/ItemCountObserver.cs
+++ b/src/AntMe.Runtime/EventLog/ItemCountObserver.cs
@@ -23,22 +23,21 @@ namespace AntMe.Runtime.EventLog
                     {
                         // Faction-Item
                         var fi = item as FactionItemState;
-                        if (OnNewEvent != null)
-                            OnNewEvent(new AddFactionItemEntry() { 
-                                Round = state.Round, 
-                                Id = fi.Id, 
-                                SlotIndex = fi.SlotIndex 
-                            });
+                        OnNewEvent?.Invoke(new AddFactionItemEntry()
+                        {
+                            Round = state.Round,
+                            Id = fi.Id,
+                            SlotIndex = fi.SlotIndex
+                        });
                     }
                     else
                     {
                         // Factionloses Item
-                        if (OnNewEvent != null)
-                            OnNewEvent(new AddItemEntry()
-                            {
-                                Round = state.Round,
-                                Id = item.Id
-                            });
+                        OnNewEvent?.Invoke(new AddItemEntry()
+                        {
+                            Round = state.Round,
+                            Id = item.Id
+                        });
                     }
 
                     ids.Add(item.Id);
@@ -53,12 +52,11 @@ namespace AntMe.Runtime.EventLog
                 if (!updated.Contains(id))
                 {
                     // Item nicht mehr vorhanden
-                    if (OnNewEvent != null)
-                        OnNewEvent(new RemoveItemEntry()
-                        {
-                            Round = state.Round,
-                            Id = id
-                        });
+                    OnNewEvent?.Invoke(new RemoveItemEntry()
+                    {
+                        Round = state.Round,
+                        Id = id
+                    });
                 }
             }
         }

--- a/src/AntMe.Runtime/EventLog/Log.cs
+++ b/src/AntMe.Runtime/EventLog/Log.cs
@@ -51,8 +51,7 @@ namespace AntMe.Runtime.EventLog
         {
             entries.Add(entry);
 
-            if (OnLogEvent != null)
-                OnLogEvent(entry);
+            OnLogEvent?.Invoke(entry);
         }
 
         /// <summary>

--- a/src/AntMe.Runtime/SecureHost.cs
+++ b/src/AntMe.Runtime/SecureHost.cs
@@ -115,9 +115,7 @@ namespace AntMe.Runtime
 
         public Exception GetLastException()
         {
-            if (_level != null)
-                return _level.LastException;
-            return null;
+            return _level?.LastException;
         }
     }
 }

--- a/src/AntMe.Runtime/SecureSimulation.cs
+++ b/src/AntMe.Runtime/SecureSimulation.cs
@@ -116,11 +116,8 @@ namespace AntMe.Runtime
                 AppDomain.Unload(_appDomain);
                 _appDomain = null;
 
-                if (_deserializer != null)
-                {
-                    _deserializer.Dispose();
-                    _deserializer = null;
-                }
+                _deserializer?.Dispose();
+                _deserializer = null;
             }
         }
 

--- a/src/AntMe.Runtime/TypeMapper.Factions.cs
+++ b/src/AntMe.Runtime/TypeMapper.Factions.cs
@@ -94,9 +94,7 @@ namespace AntMe.Runtime
         public string LookupFactionName(Type playerType)
         {
             var faction = factions.FirstOrDefault(f => playerType.IsSubclassOf(f.FactoryType));
-            if (faction != null)
-                return faction.Type.FullName;
-            return null;
+            return faction?.Type.FullName;
         }
 
         #endregion


### PR DESCRIPTION
This changes the code to use the new null-propagating operator (?.) and null-coalescing operator (??), when possible and it increases the simplicity of the code.

All changes made have no observable sideeffects other than added thread-safety except for in three cases where I fixed smaller bugs:
In `CoreTestClient.BaseSceneControl::set_HoveredCell`: The value of the property didn't update when no OnChanged delegate is set. In `AntMe.Runtime.Communication.LocalSimulationClient`: Some methods checked for OnSimulationState and than called OnSimulationChanged, they now call OnSimulationChanged if it is set and ignore OnSimulationState. In `AntMe.Basics.Factions.DeathCountProperty`1::set_DamageCount`: Again the null check was for an other delegate than it was called.
(The removed assignment `mapSize = size;` at the beginning of the diff was rendunant, because it happes a couple of line above unconditionally and nether variable can change between both assingnments (Except for in an other Thread but this would most likely result in a nasty, hard to find race condition bug))
