### PR TITLE
Fixed: Travis CI Build

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -118,7 +118,8 @@ Task("test")
         {
             OutputDirectory = "./output/xunit",
             XmlReport = true,
-            Parallelism = parallelOption
+            Parallelism = parallelOption,
+            NoAppDomain = ! IsRunningOnWindows()
         });
     }).Finally(() => 
     {

--- a/build.cake
+++ b/build.cake
@@ -112,11 +112,13 @@ Task("test")
     {
         CreateDirectory("./output/xunit");
     
+        var parallelOption = IsRunningOnWindows() ? ParallelismOption.All : ParallelismOption.None;
+
         XUnit2(Tests, new XUnit2Settings
         {
             OutputDirectory = "./output/xunit",
             XmlReport = true,
-            Parallelism = ParallelismOption.All
+            Parallelism = parallelOption
         });
     }).Finally(() => 
     {


### PR DESCRIPTION
Due to a bug in Mono 4 in combination with xunit console runner the test discovery randomly fails.

I fixed this with disabling parallel testing on OSX and Linux, like supposed here: xunit/xunit#564

**Update 1:** It seams that there is still another issue for Linux builds. See #12 
